### PR TITLE
Show connect wallet button, if it wasn't connected before

### DIFF
--- a/components/header/header.tsx
+++ b/components/header/header.tsx
@@ -6,7 +6,7 @@ import {
   HeaderLogoStyle,
   HeaderActionsStyle,
 } from './headerStyles';
-import HeaderWallet from './headerWallet';
+import { HeaderWallet } from './headerWallet';
 
 const Header: FC = () => (
   <HeaderStyle size="full" forwardedAs="header">

--- a/components/header/headerWallet.tsx
+++ b/components/header/headerWallet.tsx
@@ -3,13 +3,11 @@ import { CHAINS, getChainColor } from '@lido-sdk/constants';
 import { useSDK } from '@lido-sdk/react';
 import { useWeb3 } from '@reef-knot/web3-react';
 import { ThemeToggler } from '@lidofinance/lido-ui';
-
-import WalletButton from 'components/walletButton';
-import WalletConnect from 'components/walletConnect';
-
+import { WalletButton } from 'components/walletButton';
+import { WalletConnect } from 'components/walletConnect';
 import { HeaderWalletChainStyle } from './headerWalletStyles';
 
-const HeaderWallet: FC = () => {
+export const HeaderWallet: FC = () => {
   const { active } = useWeb3();
   const { chainId } = useSDK();
 
@@ -29,5 +27,3 @@ const HeaderWallet: FC = () => {
     </>
   );
 };
-
-export default HeaderWallet;

--- a/components/main/mainStyles.tsx
+++ b/components/main/mainStyles.tsx
@@ -5,4 +5,9 @@ export const MainStyle = styled(Container)`
   position: relative;
   margin-top: ${({ theme }) => theme.spaceMap.sm}px;
   margin-bottom: ${({ theme }) => theme.spaceMap.sm}px;
+  min-height: 50vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  alight-items: center;
 `;

--- a/components/transaction/transaction.tsx
+++ b/components/transaction/transaction.tsx
@@ -124,6 +124,7 @@ export const transaction = async <T extends TransactionReceipt>(
   } catch (error) {
     if (pendingToastId) toast.dismiss(pendingToastId);
     showError(error);
+    throw error;
   }
 
   return result;

--- a/components/transaction/transaction.tsx
+++ b/components/transaction/transaction.tsx
@@ -124,7 +124,6 @@ export const transaction = async <T extends TransactionReceipt>(
   } catch (error) {
     if (pendingToastId) toast.dismiss(pendingToastId);
     showError(error);
-    throw error;
   }
 
   return result;

--- a/components/walletButton/index.ts
+++ b/components/walletButton/index.ts
@@ -1,1 +1,1 @@
-export { default as default } from './walletButton';
+export * from './walletButton';

--- a/components/walletButton/walletButton.tsx
+++ b/components/walletButton/walletButton.tsx
@@ -12,7 +12,7 @@ import { useEthereumBalance, useSDK } from '@lido-sdk/react';
 import FormatToken from 'components/formatToken';
 import { MODAL } from 'providers';
 
-const WalletButton: FC<ButtonProps> = (props) => {
+export const WalletButton: FC<ButtonProps> = (props) => {
   const { onClick, ...rest } = props;
   const { openModal } = useModal(MODAL.wallet);
   const { account } = useSDK();
@@ -39,5 +39,3 @@ const WalletButton: FC<ButtonProps> = (props) => {
     </WalledButtonStyle>
   );
 };
-
-export default WalletButton;

--- a/components/walletConnect/index.ts
+++ b/components/walletConnect/index.ts
@@ -1,1 +1,1 @@
-export { default as default } from './walletConnect';
+export * from './walletConnect';

--- a/components/walletConnect/walletConnect.tsx
+++ b/components/walletConnect/walletConnect.tsx
@@ -3,7 +3,7 @@ import { Button, ButtonProps } from '@lidofinance/lido-ui';
 import { useModal } from 'hooks';
 import { MODAL } from 'providers';
 
-const WalletConnect: FC<ButtonProps> = (props) => {
+export const WalletConnect: FC<ButtonProps> = (props) => {
   const { onClick, ...rest } = props;
   const { openModal } = useModal(MODAL.connect);
 
@@ -13,5 +13,3 @@ const WalletConnect: FC<ButtonProps> = (props) => {
     </Button>
   );
 };
-
-export default WalletConnect;

--- a/features/home/claim-form/claim-form.tsx
+++ b/features/home/claim-form/claim-form.tsx
@@ -13,12 +13,15 @@ import { useClaimingContext, useVestingsContext } from '../providers';
 import { SelectVesting } from './inputs/select-vesting';
 import { InputUnvestAmount } from './inputs/input-unvest-amount';
 import { InputCustomAddress } from './inputs/input-custom-address';
-import { Button, Loader } from '@lidofinance/lido-ui';
-import { LoaderWrapperStyled, NoProgramStyled } from './styles';
+import { Button } from '@lidofinance/lido-ui';
+import { NoProgramStyled } from './styles';
+import { useWeb3 } from 'reef-knot';
+import { WalletConnect } from 'components/walletConnect';
 
 export const ClaimForm: FC = () => {
   const { vestings, currentVesting, isLoading, setCurrentVesting } =
     useVestingsContext();
+  const { isClaiming, setIsClaiming } = useClaimingContext();
 
   const [amountTouched, setAmountTouched] = useState(false);
   const [amount, setAmount] = useState('');
@@ -26,10 +29,12 @@ export const ClaimForm: FC = () => {
   const [addressTouched, setAddressTouched] = useState(false);
   const [address, setAddress] = useState('');
 
-  const didMountRef = useRef(false);
   const claim = useVestingClaim(currentVesting);
   const unclaimed = useVestingUnclaimed(currentVesting);
-  const { isClaiming, setIsClaiming } = useClaimingContext();
+
+  const { active, account } = useWeb3();
+
+  const didMountRef = useRef(false);
 
   useEffect(() => {
     if (didMountRef.current) setAmountTouched(true);
@@ -64,9 +69,11 @@ export const ClaimForm: FC = () => {
 
       try {
         await claim(amount, address);
+      } catch (e) {
+        // do nothing, we already shown error
+        // TODO: error handling should be made here
       } finally {
         setIsClaiming(false);
-        setAmount('');
       }
     },
     [claim, amount, setIsClaiming, address],
@@ -85,15 +92,7 @@ export const ClaimForm: FC = () => {
   const amountRenderedError = amountTouched ? amountError : null;
   const addressRenderedError = addressTouched ? addressError : null;
 
-  if (isLoading) {
-    return (
-      <LoaderWrapperStyled>
-        <Loader />
-      </LoaderWrapperStyled>
-    );
-  }
-
-  if (currentVesting == null) {
+  if (account != null && active && !isLoading && currentVesting == null) {
     return <NoProgramStyled>Don&apos;t have program</NoProgramStyled>;
   }
 
@@ -117,14 +116,18 @@ export const ClaimForm: FC = () => {
         onChange={setAddress}
         error={addressRenderedError}
       />
-      <Button
-        fullwidth
-        loading={isClaiming}
-        disabled={disabled}
-        onClick={handleClaim}
-      >
-        Claim
-      </Button>
+      {active ? (
+        <Button
+          fullwidth
+          loading={isClaiming}
+          disabled={disabled}
+          onClick={handleClaim}
+        >
+          Claim
+        </Button>
+      ) : (
+        <WalletConnect fullwidth />
+      )}
     </form>
   );
 };

--- a/features/home/claim-form/claim-form.tsx
+++ b/features/home/claim-form/claim-form.tsx
@@ -69,9 +69,6 @@ export const ClaimForm: FC = () => {
 
       try {
         await claim(amount, address);
-      } catch (e) {
-        // do nothing, we already shown error
-        // TODO: error handling should be made here
       } finally {
         setIsClaiming(false);
       }

--- a/features/home/claim-form/claim-form.tsx
+++ b/features/home/claim-form/claim-form.tsx
@@ -109,6 +109,7 @@ export const ClaimForm: FC = () => {
           onChange={setAmount}
           maxValue={unclaimed}
           error={amountRenderedError}
+          maxDisabled={account == null}
         />
       </SelectVesting>
       <InputCustomAddress

--- a/features/home/claim-form/inputs/input-unvest-amount.tsx
+++ b/features/home/claim-form/inputs/input-unvest-amount.tsx
@@ -7,6 +7,7 @@ type ClaimInputProps = {
   error?: string | null;
   maxValue: { data?: BigNumber; loading: boolean };
   onChange: (value: string) => unknown;
+  maxDisabled?: boolean;
 };
 
 export const InputUnvestAmount = ({
@@ -14,6 +15,7 @@ export const InputUnvestAmount = ({
   onChange,
   maxValue,
   error,
+  maxDisabled = false,
 }: ClaimInputProps) => (
   <Input
     fullwidth
@@ -22,6 +24,7 @@ export const InputUnvestAmount = ({
       <Button
         size="xxs"
         variant="translucent"
+        disabled={maxDisabled}
         onClick={() => onChange(formatEther(maxValue.data || '0'))}
       >
         Max

--- a/features/home/claim-form/inputs/select-vesting.tsx
+++ b/features/home/claim-form/inputs/select-vesting.tsx
@@ -6,8 +6,8 @@ import { InputGroupStyled } from '../styles';
 
 type ClaimInputProps = PropsWithChildren<{
   error?: string | ReactNode;
-  value: string;
-  options: string[];
+  value: string | undefined;
+  options?: string[];
   onChange: (value: string) => unknown;
 }>;
 


### PR DESCRIPTION
## Description

- If the wallet is not connected, added a button to connect it right away, as it was made on staking widget

On staking widget

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/103929444/225699353-076e1135-8037-4de1-8575-96175e76cabe.png">

TRP UI

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/103929444/225700151-ad568aef-b472-43f2-9a19-e7dacd13c60b.png">

- Centered content

Before
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/103929444/225699513-a0e29c20-4af1-4745-9ded-d5f55b16c05e.png">

After
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/103929444/225699590-a851daf5-b8ec-41e7-a6c8-600101268462.png">

## How Has This Been Tested?

Wallet connected, there are no programs

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/103929444/225699769-e8424c13-d5c5-449f-99d3-73532bba9ce1.png">

Wallet connected, there are programs

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/103929444/225699855-1e83b329-5c95-4fd4-a223-85059acbec86.png">

Wallet not connected

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/103929444/225699924-7bba0b4e-836d-4796-8d4d-6dfa26e5a499.png">
