### PR TITLE
Fixed token name on staging

### DIFF
--- a/config/tokens.ts
+++ b/config/tokens.ts
@@ -1,8 +1,13 @@
-export const TOKENS_BY_ADDRESS: Record<string, string> = {
+// Must be lowercase
+const TOKENS_BY_ADDRESS: Record<string, string> = {
   '0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0': 'WSTETH', // mainnet
-  '0x6320cD32aA674d2898A68ec82e869385Fc5f7E2f': 'WSTETH', // testnet
+  '0x6320cd32aa674d2898a68ec82e869385fc5f7e2f': 'WSTETH', // testnet
   '0xae7ab96520de3a18e5e111b5eaab095312d7fe84': 'STETH', // mainnet
   '0x1643e812ae58766192cf7d2cf9567df2c37e9b7f': 'STETH', // testnet
   '0x5a98fcbea516cf06857215779fd812ca3bef1b32': 'LDO',
-  '0x56340274fB5a72af1A3C6609061c451De7961Bd4': 'TESTLDO',
+  '0x56340274fb5a72af1a3c6609061c451de7961bd4': 'TESTLDO',
+};
+
+export const getTokenByAddress = (address: string): string => {
+  return TOKENS_BY_ADDRESS[address.toLowerCase()] ?? '';
 };

--- a/hooks/useVestingContract.ts
+++ b/hooks/useVestingContract.ts
@@ -5,7 +5,7 @@ import { useWeb3 } from 'reef-knot';
 import { VestingEscrow__factory } from 'generated';
 import { utils } from 'ethers';
 import { transaction } from 'components/transaction';
-import { TOKENS_BY_ADDRESS } from 'config';
+import { getTokenByAddress } from 'config';
 
 const { parseEther } = utils;
 
@@ -61,7 +61,7 @@ export const useVestingToken = (address = '') => {
 
   return {
     address: data,
-    symbol: TOKENS_BY_ADDRESS[data] ?? '',
+    symbol: getTokenByAddress(data),
   };
 };
 


### PR DESCRIPTION
## Description

The issue was that the token address in local storage was `0x5a98fcbea516cf06857215779fd812ca3bef1b32`, but in contract it was '0x5A98FcBEA516Cf06857215779Fd812CA3beF1B32', so comparison didn't work.

## Demo

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/103929444/228231080-cdd19bd2-a740-495b-a783-2f9b9de08c13.png">

## Testing notes

Check if token titles still there
