### PR TITLE
Offer to connect a wallet if not connected

### DIFF
--- a/features/aragon/aragonForm.tsx
+++ b/features/aragon/aragonForm.tsx
@@ -7,6 +7,8 @@ import { InputGroupStyled, InputNumber } from 'shared/ui';
 import { useEncodeAragonCalldata } from 'features/votingAdapter';
 import { Form } from './aragonFormStyles';
 import { useGetVoting } from './useAragon';
+import { useWeb3 } from 'reef-knot';
+import { WalletConnect } from 'features/wallet';
 
 type AragonFormData = {
   voteId: string;
@@ -25,6 +27,7 @@ const validateVoteId = (value: string) => {
 };
 
 export const AragonForm = () => {
+  const { active } = useWeb3();
   const {
     register,
     handleSubmit,
@@ -78,30 +81,34 @@ export const AragonForm = () => {
           />
         </InputGroupStyled>
 
-        <InputGroupStyled fullwidth>
-          {/* this prevents form being submitted by Enter keypress on the input */}
-          <Button type="submit" disabled style={{ display: 'none' }} />
-          <Button
-            type="submit"
-            disabled={!isValid}
-            color="success"
-            fullwidth
-            onClick={handleYesButton}
-          >
-            Yes
-          </Button>
-          <Button
-            type="submit"
-            disabled={!isValid}
-            color="error"
-            fullwidth
-            onClick={handleNoButton}
-          >
-            No
-          </Button>
-          {/* need to register success form value */}
-          <input type="hidden" {...register('success')} />
-        </InputGroupStyled>
+        {active ? (
+          <InputGroupStyled fullwidth>
+            {/* this prevents form being submitted by Enter keypress on the input */}
+            <Button type="submit" disabled style={{ display: 'none' }} />
+            <Button
+              type="submit"
+              disabled={!isValid}
+              color="success"
+              fullwidth
+              onClick={handleYesButton}
+            >
+              Yes
+            </Button>
+            <Button
+              type="submit"
+              disabled={!isValid}
+              color="error"
+              fullwidth
+              onClick={handleNoButton}
+            >
+              No
+            </Button>
+            {/* need to register success form value */}
+            <input type="hidden" {...register('success')} />
+          </InputGroupStyled>
+        ) : (
+          <WalletConnect fullwidth />
+        )}
       </Form>
     </Block>
   );

--- a/features/snapshot/snapshotForm.tsx
+++ b/features/snapshot/snapshotForm.tsx
@@ -6,6 +6,8 @@ import { InputGroupStyled } from 'shared/ui';
 import { InputAddress, addressValidator } from 'shared/ui/inputAddress';
 import { useEncodeSnapshotCalldata } from 'features/votingAdapter';
 import { Form } from './snapshotFormStyles';
+import { useWeb3 } from 'reef-knot';
+import { WalletConnect } from 'features/wallet';
 
 type SnapshotFormData = {
   delegateAddress: string;
@@ -14,6 +16,7 @@ type SnapshotFormData = {
 const validateAddress = addressValidator();
 
 export const SnapshotForm = () => {
+  const { active } = useWeb3();
   const {
     register,
     handleSubmit,
@@ -51,9 +54,13 @@ export const SnapshotForm = () => {
           />
         </InputGroupStyled>
 
-        <Button type="submit" disabled={!isValid}>
-          Delegate
-        </Button>
+        {active ? (
+          <Button type="submit" disabled={!isValid}>
+            Delegate
+          </Button>
+        ) : (
+          <WalletConnect fullwidth />
+        )}
       </Form>
     </Block>
   );


### PR DESCRIPTION
## Description

If wallet is not connected, it's not possible to delegate votes on Snapshot or vote on Aragon, so we need to replace submit buttons with a button, which offers connecting a wallet

## Demo

Aragon (wallet disconnected)
<img width="1512" alt="Screenshot 2023-05-02 at 15 07 43" src="https://user-images.githubusercontent.com/103929444/235676397-d457d648-b013-4aa6-975b-243c28039185.png">

Aragon (wallet connected)
<img width="1512" alt="Screenshot 2023-05-02 at 15 09 39" src="https://user-images.githubusercontent.com/103929444/235676455-c7cf532c-1db3-47a5-b5e3-275aee1868ba.png">

Snapshot (wallet disconnected)
<img width="1512" alt="Screenshot 2023-05-02 at 15 08 38" src="https://user-images.githubusercontent.com/103929444/235676518-a2412bc9-9e7b-46a4-9bcd-9fe51d48349d.png">

Snapshot (wallet connected)
<img width="1512" alt="Screenshot 2023-05-02 at 15 09 33" src="https://user-images.githubusercontent.com/103929444/235676571-6aaa977e-162e-4dca-9518-d24c311ce6ed.png">

## Review notes

x

## Testing notes

Need to check if everything works as usual