### PR TITLE
Show error even with inactive wallet

### DIFF
--- a/features/aragon/aragon.tsx
+++ b/features/aragon/aragon.tsx
@@ -17,19 +17,19 @@ export const Aragon = () => {
     return <InlineLoader style={{ height: '50px' }} />;
   }
 
-  if (!active) {
-    return (
-      <Main>
-        <AragonFormDisconnected />
-      </Main>
-    );
-  }
-
   if (walletError != null) {
     return (
       <Main>
         <Main.ErrorWallet>{walletError}</Main.ErrorWallet>
         <AragonFormError />
+      </Main>
+    );
+  }
+
+  if (!active) {
+    return (
+      <Main>
+        <AragonFormDisconnected />
       </Main>
     );
   }

--- a/features/claim/claim.tsx
+++ b/features/claim/claim.tsx
@@ -17,19 +17,19 @@ export const Claim = () => {
     return <InlineLoader style={{ height: '50px' }} />;
   }
 
-  if (!active) {
-    return (
-      <Main>
-        <ClaimFormDisconnected />
-      </Main>
-    );
-  }
-
   if (walletError != null) {
     return (
       <Main>
         <Main.ErrorWallet>{walletError}</Main.ErrorWallet>
         <ClaimFormError />
+      </Main>
+    );
+  }
+
+  if (!active) {
+    return (
+      <Main>
+        <ClaimFormDisconnected />
       </Main>
     );
   }

--- a/features/snapshot/snapshot.tsx
+++ b/features/snapshot/snapshot.tsx
@@ -17,19 +17,19 @@ export const Snapshot = () => {
     return <InlineLoader style={{ height: '50px' }} />;
   }
 
-  if (!active) {
-    return (
-      <Main>
-        <SnapshotFormDisconnected />
-      </Main>
-    );
-  }
-
   if (walletError != null) {
     return (
       <Main>
         <Main.ErrorWallet>{walletError}</Main.ErrorWallet>
         <SnapshotFormError />
+      </Main>
+    );
+  }
+
+  if (!active) {
+    return (
+      <Main>
+        <SnapshotFormDisconnected />
       </Main>
     );
   }


### PR DESCRIPTION
## Description

If wallet is inactive, it doesn't mean there are no errors

## Demo

<img width="551" alt="image" src="https://github.com/lidofinance/trp-ui/assets/103929444/1aad7f6e-11e0-4ab1-9e88-7d36e88a2644">

## Testing notes

Need to test home/aragon/snapshot pages
