### PR TITLE
Clear claim amount on vesting change

### DIFF
--- a/features/claim/claimForm.tsx
+++ b/features/claim/claimForm.tsx
@@ -27,7 +27,6 @@ export const ClaimForm: FC = () => {
     register,
     handleSubmit,
     setValue,
-    trigger,
     formState: { isDirty, isValid, errors },
   } = useForm<ClaimFormData>({ mode: 'onChange' });
 
@@ -47,9 +46,9 @@ export const ClaimForm: FC = () => {
   // Validate form if vestings changes
   useEffect(() => {
     if (isDirty) {
-      trigger();
+      setValue('amount', '');
     }
-  }, [isDirty, trigger, activeVesting]);
+  }, [setValue, isDirty, activeVesting]);
 
   const validateAmount = useCallback(
     (data: string) =>


### PR DESCRIPTION
## Demo

Filled input
<img width="535" alt="Screenshot 2023-05-19 at 13 10 19" src="https://github.com/lidofinance/trp-ui/assets/103929444/6c793644-be4d-4dfe-8e3c-713a3b09094a">

Changed vesting
<img width="535" alt="Screenshot 2023-05-19 at 13 10 26" src="https://github.com/lidofinance/trp-ui/assets/103929444/3a17aa9e-c674-4d4b-a587-42fdcaa760c1">

## Testing notes

Changing vesting should clear
Claim should work as normal