### PR TITLE
Disable ended programs on admin interface

### DIFF
--- a/pages/admin.tsx
+++ b/pages/admin.tsx
@@ -10,6 +10,7 @@ import { H3 } from '@lidofinance/lido-ui';
 const AdminPage: FC = () => {
   const router = useRouter();
   const isAdmin = useIsAdmin();
+
   useEffect(() => {
     if (isAdmin === false) {
       router.push('/');


### PR DESCRIPTION
## Description

There is no point in revoking program where no locked tokens

## Demo

<img width="1247" alt="image" src="https://github.com/lidofinance/trp-ui/assets/103929444/75c59373-7cce-4afb-92a1-6e917a61b2bc">

## Testing notes

Check if there are three statuses Ended / Revoked / Active and it's still possible to revoke an Active program
