### PR TITLE
Use FixedNumber for usd price calculation

### DIFF
--- a/features/claim/wallet.tsx
+++ b/features/claim/wallet.tsx
@@ -30,17 +30,15 @@ export const Wallet: FC = () => {
 
   const { data: unclaimed, isLoading: unclaimedIsLoading } =
     useVestingsUnclaimed(escrows);
-  const { data: locked, isLoading: lockedIsLoading } =
-    useVestingsLocked(escrows);
-
-  // both  swr subscribe to same request cache and do not spam requests
-  const { amountUsd: lockedAmountUsd, initialLoading: lockedAmountUsdLoading } =
-    useLdoPrice(locked);
-
   const {
     amountUsd: unclaimedAmountUsd,
     initialLoading: unclaimedAmountUsdLoading,
   } = useLdoPrice(unclaimed);
+
+  const { data: locked, isLoading: lockedIsLoading } =
+    useVestingsLocked(escrows);
+  const { amountUsd: lockedAmountUsd, initialLoading: lockedAmountUsdLoading } =
+    useLdoPrice(locked);
 
   return (
     <Main.Wallet>
@@ -81,7 +79,7 @@ export const Wallet: FC = () => {
             {unclaimedAmountUsdLoading ? (
               <InlineLoader />
             ) : (
-              <FormatToken approx amount={unclaimedAmountUsd} symbol={'USD'} />
+              <>≈{unclaimedAmountUsd?.round(1).toString()} USD</>
             )}
           </div>
         </Main.Column>
@@ -110,7 +108,7 @@ export const Wallet: FC = () => {
             {lockedAmountUsdLoading ? (
               <InlineLoader />
             ) : (
-              <FormatToken approx amount={lockedAmountUsd} symbol={'USD'} />
+              <>≈{lockedAmountUsd?.round(2).toString()} USD</>
             )}
           </div>
         </Main.Column>


### PR DESCRIPTION
## Description

Using multiplier 10_000 to avoid fractal points wasn't working in some cases, which caused BigNumber [underflow](https://docs.ethers.org/v5/troubleshooting/errors/#help-NUMERIC_FAULT-underflow).

## Demo

<img width="1282" alt="image" src="https://github.com/lidofinance/trp-ui/assets/103929444/36f319c7-0c76-49dd-9aef-e1fa8d317b6a">

## Review notes

## Testing notes

Normal checks
