### PR TITLE
Add favicon and metadata for trp UI

### DIFF
--- a/features/claim/wallet.tsx
+++ b/features/claim/wallet.tsx
@@ -69,19 +69,25 @@ export const Wallet: FC = () => {
               <InlineLoader />
             ) : (
               <>
-                <TokensAmount>
-                  <FormatToken amount={unclaimed} symbol={token?.symbol} />
-                </TokensAmount>
-                &nbsp;
-                <TokenToWallet address={token?.address} />
+                <div>
+                  <TokensAmount>
+                    <FormatToken amount={unclaimed} symbol={token?.symbol} />
+                  </TokensAmount>
+                  &nbsp;
+                  <TokenToWallet address={token?.address} />
+                </div>
+                <div>
+                  {unclaimedAmountUsdLoading ? (
+                    <InlineLoader />
+                  ) : (
+                    <FormatToken
+                      approx
+                      amount={unclaimedAmountUsd}
+                      symbol={'USD'}
+                    />
+                  )}
+                </div>
               </>
-            )}
-          </div>
-          <div>
-            {unclaimedAmountUsdLoading ? (
-              <InlineLoader />
-            ) : (
-              <FormatToken approx amount={unclaimedAmountUsd} symbol={'USD'} />
             )}
           </div>
         </Main.Column>
@@ -97,21 +103,27 @@ export const Wallet: FC = () => {
                 <InlineLoader />
               ) : (
                 <>
-                  <TokensAmount>
-                    <FormatToken amount={locked} symbol={token?.symbol} />
-                  </TokensAmount>
-                  &nbsp;
-                  <TokenToWallet address={token?.address} />
+                  <div>
+                    <TokensAmount>
+                      <FormatToken amount={locked} symbol={token?.symbol} />
+                    </TokensAmount>
+                    &nbsp;
+                    <TokenToWallet address={token?.address} />
+                  </div>
+                  <div>
+                    {lockedAmountUsdLoading ? (
+                      <InlineLoader />
+                    ) : (
+                      <FormatToken
+                        approx
+                        amount={lockedAmountUsd}
+                        symbol={'USD'}
+                      />
+                    )}
+                  </div>
                 </>
               )}
             </SecondaryText>
-          </div>
-          <div>
-            {lockedAmountUsdLoading ? (
-              <InlineLoader />
-            ) : (
-              <FormatToken approx amount={lockedAmountUsd} symbol={'USD'} />
-            )}
           </div>
         </Main.Column>
       </Main.Row>

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -10,15 +10,10 @@ import { Fonts, LidoUIHead } from '@lidofinance/lido-ui';
 import { ServerStyleSheet } from 'styled-components';
 import { dynamics } from '../config';
 
-// for prod and dev use https and real domain
-let host = 'http://localhost:3000';
-
 const metaTitle = 'TRP UI | Lido';
 const metaDescription = 'Lido Token Rewards Plan for the contributors.';
 
 const CustomDocument = () => {
-  const metaPreviewImgUrl = `${host}/lido-preview.png`;
-
   return (
     <Html lang="en">
       <Head>
@@ -56,12 +51,10 @@ const CustomDocument = () => {
         <meta property="og:type" content="website" />
         <meta property="og:title" content={metaTitle} />
         <meta property="og:description" content={metaDescription} />
-        <meta property="og:image" content={metaPreviewImgUrl} />
 
         <meta name="twitter:card" content="summary_large_image" />
         <meta name="twitter:title" content={metaTitle} />
         <meta name="twitter:description" content={metaDescription} />
-        <meta name="twitter:image:src" content={metaPreviewImgUrl} />
         <meta name="twitter:site" content="@lidofinance" />
         <meta name="twitter:creator" content="@lidofinance" />
 
@@ -82,10 +75,6 @@ CustomDocument.getInitialProps = async (
 ): Promise<DocumentInitialProps> => {
   const sheet = new ServerStyleSheet();
   const originalRenderPage = ctx.renderPage;
-
-  if (ctx?.req?.headers?.host) {
-    host = `https://${ctx?.req?.headers?.host}`;
-  }
 
   try {
     ctx.renderPage = () =>

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -11,18 +11,17 @@ import { ServerStyleSheet } from 'styled-components';
 import { dynamics } from '../config';
 
 // for prod and dev use https and real domain
-let host = 'http://localhost';
+let host = 'http://localhost:3000';
 
 const metaTitle = 'TRP UI | Lido';
 const metaDescription = 'Lido Token Rewards Plan for the contributors.';
-const metaPreviewImgUrl = `${host}/lido-preview.png`;
 
 const CustomDocument = () => {
+  const metaPreviewImgUrl = `${host}/lido-preview.png`;
+
   return (
     <Html lang="en">
       <Head>
-        <link rel="manifest" href="/manifest.json" />
-        <link rel="icon" href="/favicon.ico" sizes="any" />
         <link rel="icon" type="image/svg+xml" href="favicon-512x512.svg" />
         <link
           rel="apple-touch-icon"
@@ -47,18 +46,25 @@ const CustomDocument = () => {
           sizes="16x16"
           href="/favicon-16x16.png"
         />
+
+        <link rel="manifest" href="/manifest.json" />
+
+        <title>{metaTitle}</title>
+        <meta name="description" content={metaDescription} />
+        <meta name="currentChain" content={String(dynamics.defaultChain)} />
+
         <meta property="og:type" content="website" />
         <meta property="og:title" content={metaTitle} />
         <meta property="og:description" content={metaDescription} />
         <meta property="og:image" content={metaPreviewImgUrl} />
+
         <meta name="twitter:card" content="summary_large_image" />
         <meta name="twitter:title" content={metaTitle} />
         <meta name="twitter:description" content={metaDescription} />
         <meta name="twitter:image:src" content={metaPreviewImgUrl} />
         <meta name="twitter:site" content="@lidofinance" />
         <meta name="twitter:creator" content="@lidofinance" />
-        <meta name="description" content={metaDescription} />
-        <meta name="currentChain" content={String(dynamics.defaultChain)} />
+
         <Fonts />
         <LidoUIHead />
         <script src="/runtime/window-env.js" />

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -17,11 +17,16 @@ const CustomDocument = () => {
   return (
     <Html lang="en">
       <Head>
-        <link rel="icon" type="image/svg+xml" href="favicon-512x512.svg" />
         <link
           rel="apple-touch-icon"
           sizes="180x180"
           href="/apple-touch-icon.png"
+        />
+        <link
+          rel="icon"
+          type="image/svg+xml"
+          sizes="512x512"
+          href="/favicon-512x512.svg"
         />
         <link
           rel="icon"

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
-  "name": "Lido Frontend Template",
-  "short_name": "Lido",
-  "description": "Lido is the liquid staking solution for Ethereum.",
+  "name": "TRP UI | Lido",
+  "short_name": "TRP UI",
+  "description": "Lido Token Rewards Plan for the contributors",
   "iconPath": "favicon-512x512.svg",
   "icons": [
     {


### PR DESCRIPTION
## Description

1. Added HTML title.
2. Removed image preview, since there is no image (will add if it will be needed).
3. Small fix for USD preview.

## Demo

Before
<img width="1512" alt="image" src="https://github.com/lidofinance/trp-ui/assets/103929444/a57897f2-e80b-4723-be65-b186acf63617">

After
<img width="1512" alt="image" src="https://github.com/lidofinance/trp-ui/assets/103929444/da5d889b-a7d4-40ed-a96c-4398121e2b5c">

## Review notes

## Testing notes

Check if all content in <head> makes sense